### PR TITLE
update Vagrant to 2.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y \
     rsync
 
 RUN pip install 'requests[security]' ansible~=2.4.0
-RUN yum install -y https://releases.hashicorp.com/vagrant/2.0.0/vagrant_2.0.0_x86_64.rpm
+RUN yum install -y https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.rpm
 RUN vagrant plugin install vagrant-google
 
 CMD ansible


### PR DESCRIPTION
This is needed for the _vagrant-google_ plugin: https://github.com/mitchellh/vagrant-google/issues/188